### PR TITLE
Use explicit loader instead of jupyterlab fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ A JupyterLab extension providing the [Monaco](https://github.com/Microsoft/monac
 ## Prerequisites
 
 * JupyterLab 0.32
-* The modifications at https://github.com/jupyterlab/jupyterlab/issues/4406 must be applied to the JupyterLab webpack config (usually in the `site-packages/jupyterlab/staging/webpack.config.js`)
 
 ## Development
 

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,0 +1,4 @@
+declare module 'file-loader!*' {
+    var url: string;
+    export = url;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,11 +44,11 @@ import * as monaco from 'monaco-editor';
 
 import '../style/index.css';
 
-import * as monacoCSS from '../lib/JUPYTERLAB_FILE_LOADER_jupyterlab-monaco-css.worker.bundle.js';
-import * as monacoEditor from '../lib/JUPYTERLAB_FILE_LOADER_jupyterlab-monaco-editor.worker.bundle.js';
-import * as monacoHTML from '../lib/JUPYTERLAB_FILE_LOADER_jupyterlab-monaco-html.worker.bundle.js';
-import * as monacoJSON from '../lib/JUPYTERLAB_FILE_LOADER_jupyterlab-monaco-json.worker.bundle.js';
-import * as monacoTS from '../lib/JUPYTERLAB_FILE_LOADER_jupyterlab-monaco-ts.worker.bundle.js';
+import * as monacoCSS from 'file-loader!../lib/JUPYTERLAB_FILE_LOADER_jupyterlab-monaco-css.worker.bundle.js';
+import * as monacoEditor from 'file-loader!../lib/JUPYTERLAB_FILE_LOADER_jupyterlab-monaco-editor.worker.bundle.js';
+import * as monacoHTML from 'file-loader!../lib/JUPYTERLAB_FILE_LOADER_jupyterlab-monaco-html.worker.bundle.js';
+import * as monacoJSON from 'file-loader!../lib/JUPYTERLAB_FILE_LOADER_jupyterlab-monaco-json.worker.bundle.js';
+import * as monacoTS from 'file-loader!../lib/JUPYTERLAB_FILE_LOADER_jupyterlab-monaco-ts.worker.bundle.js';
 
 
 let URLS: {[key: string]: string} = {


### PR DESCRIPTION
We can avoid any custom jupyterlab changes by using an explicit webpack loader in the import path and telling typescript that these will be imported as strings.

I think this solution could replace the change suggested in https://github.com/jupyterlab/jupyterlab/issues/4406 